### PR TITLE
Bump dependency upper bounds

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -18,7 +18,7 @@ category:            Web
 description:         Please see the README on GitHub at <https://github.com/launchdarkly/haskell-server-sdk#readme>
 
 dependencies:
-- aeson >=1.4.4.0 && <1.5
+- aeson >=1.4.4.0 && <1.6
 - attoparsec >=0.13.2.2 && <0.14
 - base >=4.7 && <5
 - base16-bytestring >=0.1.1.6 && <0.2
@@ -28,11 +28,11 @@ dependencies:
 - containers >=0.6.0.1 && <0.7
 - cryptohash >=0.11.9 && <0.12
 - exceptions >=0.10.2 && <0.11
-- extra >=1.6.17 && <1.7
-- generic-lens >=1.1.0.0 && <1.2
+- extra >=1.6.17 && <1.8
+- generic-lens >=1.1.0.0 && <2.1
 - hashtables >=1.2.3.4 && <1.3
 - hedis >=0.12.7 && <0.13
-- http-client >=0.6.4 && <0.7
+- http-client >=0.6.4 && <0.8
 - http-client-tls >=0.3.5.3 && <0.4
 - http-types >=0.12.3 && <0.13
 - iso8601-time >=0.1.5 && <0.2
@@ -41,12 +41,12 @@ dependencies:
 - monad-logger >=0.3.30 && <0.4
 - mtl >=2.2.2 && <2.3
 - pcre-light >=0.4.0.4 && <0.5
-- random ==1.1.*
+- random >=1.1 && <1.3
 - retry >=0.8.0.1 && <0.9
 - scientific >=0.3.6.2 && <0.4
 - semver >=0.3.4 && <0.4
 - text >=1.2.3.1 && <1.3
-- time >=1.8.0.2 && <1.10
+- time >=1.8.0.2 && <1.11
 - unordered-containers >=0.2.10.0 && <0.3
 - uuid >=1.3.13 && <1.4
 - vector >=0.12.0.3 && <0.13


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

(I wasn't able to identify what validation against all platforms looks like; I don't think it's relevant in this case)

**Related issues**

n/a

**Describe the solution you've provided**

Upper bounds on dependencies are more restrictive than necessary. I've bumped all the restrictive bounds in accordance with the packages' versioning policies.

The test suite succeeds with the newly allowed versions (it required `--allow-newer` as `uuid` needs a version bump — I've asked the maintainers to do that).

**Describe alternatives you've considered**

n/a

**Additional context**

n/a