### PR TITLE
Provide More Complete Support for Offline Mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 launchdarkly-server-sdk.cabal
 .stack-work/*
+dist-newstyle/
+*.*.sw*

--- a/package.yaml
+++ b/package.yaml
@@ -86,6 +86,7 @@ library:
   - LaunchDarkly.Server.Config
   - LaunchDarkly.Server.User
   - LaunchDarkly.Server.Store
+  - LaunchDarkly.Server.Features
 
 tests:
   haskell-server-sdk-test:

--- a/package.yaml
+++ b/package.yaml
@@ -102,3 +102,5 @@ tests:
     - -Wno-name-shadowing
     dependencies:
     - HUnit
+    - aeson-qq
+    - temporary

--- a/package.yaml
+++ b/package.yaml
@@ -86,7 +86,6 @@ library:
   - LaunchDarkly.Server.Config
   - LaunchDarkly.Server.User
   - LaunchDarkly.Server.Store
-  - LaunchDarkly.Server.Features
 
 tests:
   haskell-server-sdk-test:
@@ -102,5 +101,4 @@ tests:
     - -Wno-name-shadowing
     dependencies:
     - HUnit
-    - aeson-qq
     - temporary

--- a/src/LaunchDarkly/Server/Client.hs
+++ b/src/LaunchDarkly/Server/Client.hs
@@ -1,7 +1,8 @@
 -- | This module contains the core functionality of the SDK.
 
 module LaunchDarkly.Server.Client
-    ( Client
+    ( Client(..)
+    , ClientI(..)
     , makeClient
     , clientVersion
     , boolVariation

--- a/src/LaunchDarkly/Server/Client.hs
+++ b/src/LaunchDarkly/Server/Client.hs
@@ -30,14 +30,16 @@ module LaunchDarkly.Server.Client
 
 import           Control.Concurrent                    (forkFinally, killThread)
 import           Control.Concurrent.MVar               (putMVar, takeMVar, newEmptyMVar)
+import           Control.Exception                     (throwIO, Exception)
 import           Control.Monad                         (void, forM_)
 import           Control.Monad.IO.Class                (liftIO)
 import           Control.Monad.Logger                  (LoggingT, logDebug)
 import           Data.IORef                            (newIORef, writeIORef)
 import           Data.HashMap.Strict                   (HashMap)
 import qualified Data.HashMap.Strict as                HM
+import           Data.Maybe                            (isJust)
 import           Data.Text                             (Text)
-import           Data.Aeson                            (Value(..))
+import           Data.Aeson                            (Value(..), eitherDecodeFileStrict')
 import           Data.Generics.Product                 (getField, setField)
 import           Data.Scientific                       (toRealFloat, fromFloatDigits)
 import           Network.HTTP.Client                   (newManager)
@@ -51,8 +53,8 @@ import           LaunchDarkly.Server.Details           (EvaluationDetail(..), Ev
 import           LaunchDarkly.Server.Events            (IdentifyEvent(..), CustomEvent(..), AliasEvent(..), EventType(..), makeBaseEvent, queueEvent, makeEventState, addUserToEvent, userGetContextKind)
 import           LaunchDarkly.Server.Network.Eventing  (eventThread)
 import           LaunchDarkly.Server.Network.Streaming (streamingThread)
-import           LaunchDarkly.Server.Network.Polling   (pollingThread)
-import           LaunchDarkly.Server.Store.Internal    (makeStoreIO, getAllFlagsC)
+import           LaunchDarkly.Server.Network.Polling   (pollingThread, PollingResponse)
+import           LaunchDarkly.Server.Store.Internal    (makeStoreIO, getAllFlagsC, initializeStore)
 import           LaunchDarkly.Server.Evaluate          (evaluateTyped, evaluateDetail)
 
 -- | Create a new instance of the LaunchDarkly client.
@@ -77,14 +79,30 @@ makeClient (Config config) = do
         thread <- forkFinally (runLogger $ eventThread manager client) (\_ -> putMVar sync ())
         pure $ pure (thread, sync)
 
-    downloadThreadPair' <- if (getField @"offline" config) || (getField @"useLdd" config) then pure Nothing else do
+    downloadThreadPair' <- if (isJust $ getField @"offline" config) || (getField @"useLdd" config) then pure Nothing else do
         sync   <- newEmptyMVar
         thread <- forkFinally (runLogger $ downloadThreadF manager client) (\_ -> putMVar sync ())
         pure $ pure (thread, sync)
 
-    pure $ Client
+    let
+      cli = Client
         $ setField @"downloadThreadPair" downloadThreadPair'
         $ setField @"eventThreadPair"    eventThreadPair' client
+
+    case getField @"offline" config of
+      Just filepath -> do 
+        allFlags :: PollingResponse <- eitherDecodeFileStrict' filepath
+          >>= either (throwIO . ClientFailedToDecodeFile filepath) pure
+        initializeStore store (getField @"flags" allFlags) (getField @"segments" allFlags)
+          >>= either (throwIO . ClientFailedToInitializeStore) pure
+      Nothing -> pure ()
+    
+    pure cli
+
+data MakeClientInOfflineModeFailure = ClientFailedToDecodeFile FilePath String | ClientFailedToInitializeStore Text
+  deriving Show
+
+instance Exception MakeClientInOfflineModeFailure
 
 clientRunLogger :: ClientI -> (LoggingT IO () -> IO ())
 clientRunLogger client = getField @"logger" $ getField @"config" client

--- a/src/LaunchDarkly/Server/Client.hs
+++ b/src/LaunchDarkly/Server/Client.hs
@@ -90,13 +90,13 @@ makeClient (Config config) = do
         $ setField @"eventThreadPair"    eventThreadPair' client
 
     case getField @"offline" config of
-      Just filepath -> do 
-        allFlags :: PollingResponse <- eitherDecodeFileStrict' filepath
+      Just filepath -> do
+        pollingResponse :: PollingResponse <- eitherDecodeFileStrict' filepath
           >>= either (throwIO . ClientFailedToDecodeFile filepath) pure
-        initializeStore store (getField @"flags" allFlags) (getField @"segments" allFlags)
+        initializeStore store (getField @"flags" pollingResponse) (getField @"segments" pollingResponse)
           >>= either (throwIO . ClientFailedToInitializeStore) pure
       Nothing -> pure ()
-    
+
     pure cli
 
 data MakeClientInOfflineModeFailure = ClientFailedToDecodeFile FilePath String | ClientFailedToInitializeStore Text

--- a/src/LaunchDarkly/Server/Config.hs
+++ b/src/LaunchDarkly/Server/Config.hs
@@ -55,7 +55,7 @@ makeConfig key = Config $ ConfigI
     , eventsCapacity        = 10000
     , logger                = runStdoutLoggingT
     , sendEvents            = True
-    , offline               = False
+    , offline               = Nothing
     , requestTimeoutSeconds = 30
     , useLdd                = False
     , manager               = Nothing
@@ -143,7 +143,7 @@ configSetSendEvents = mapConfig . setField @"sendEvents"
 -- | Sets whether this client is offline. An offline client will not make any
 -- network connections to LaunchDarkly, and will return default values for all
 -- feature flags.
-configSetOffline :: Bool -> Config -> Config
+configSetOffline :: Maybe FilePath -> Config -> Config
 configSetOffline = mapConfig . setField @"offline"
 
 -- | Sets how long an the HTTP client should wait before a response is returned.

--- a/src/LaunchDarkly/Server/Config/Internal.hs
+++ b/src/LaunchDarkly/Server/Config/Internal.hs
@@ -7,6 +7,7 @@ module LaunchDarkly.Server.Config.Internal
 
 import Control.Monad.Logger               (LoggingT)
 import Data.Generics.Product              (getField)
+import Data.Maybe                         (isJust)
 import Data.Text                          (Text)
 import Data.Set                           (Set)
 import GHC.Natural                        (Natural)
@@ -19,7 +20,7 @@ mapConfig :: (ConfigI -> ConfigI) -> Config -> Config
 mapConfig f (Config c) = Config $ f c
 
 shouldSendEvents :: ConfigI -> Bool
-shouldSendEvents config = (not $ getField @"offline" config) && (getField @"sendEvents" config)
+shouldSendEvents config = (not . isJust $ getField @"offline" config) && (getField @"sendEvents" config)
 
 -- | Config allows advanced configuration of the LaunchDarkly client.
 newtype Config = Config ConfigI
@@ -41,7 +42,7 @@ data ConfigI = ConfigI
     , eventsCapacity        :: !Natural
     , logger                :: !(LoggingT IO () -> IO ())
     , sendEvents            :: !Bool
-    , offline               :: !Bool
+    , offline               :: !(Maybe FilePath)
     , requestTimeoutSeconds :: !Natural
     , useLdd                :: !Bool
     , manager               :: !(Maybe Manager)

--- a/src/LaunchDarkly/Server/Network/Polling.hs
+++ b/src/LaunchDarkly/Server/Network/Polling.hs
@@ -1,4 +1,4 @@
-module LaunchDarkly.Server.Network.Polling (pollingThread, PollingResponse) where
+module LaunchDarkly.Server.Network.Polling (pollingThread, PollingResponse(..)) where
 
 import           GHC.Generics                            (Generic)
 import           Data.HashMap.Strict                     (HashMap)
@@ -8,7 +8,7 @@ import           Network.HTTP.Client                     (Manager, Request(..), 
 import           Data.Generics.Product                   (getField)
 import           Control.Monad                           (forever)
 import           Control.Concurrent                      (threadDelay)
-import           Data.Aeson                              (eitherDecode, FromJSON(..))
+import           Data.Aeson                              (eitherDecode, FromJSON(..), ToJSON)
 import           Control.Monad.Logger                    (MonadLogger, logInfo, logError)
 import           Control.Monad.IO.Class                  (MonadIO, liftIO)
 import           Control.Monad.Catch                     (MonadMask, MonadThrow)
@@ -22,7 +22,7 @@ import           LaunchDarkly.Server.Store.Internal      (StoreHandle, initializ
 data PollingResponse = PollingResponse
     { flags    :: !(HashMap Text Flag)
     , segments :: !(HashMap Text Segment)
-    } deriving (Generic, FromJSON, Show)
+    } deriving (Generic, FromJSON, ToJSON, Show)
 
 processPoll :: (MonadIO m, MonadLogger m, MonadMask m, MonadThrow m) => Manager -> StoreHandle IO -> Request -> m ()
 processPoll manager store request = liftIO (tryHTTP $ httpLbs request manager) >>= \case

--- a/src/LaunchDarkly/Server/Network/Polling.hs
+++ b/src/LaunchDarkly/Server/Network/Polling.hs
@@ -1,4 +1,4 @@
-module LaunchDarkly.Server.Network.Polling (pollingThread) where
+module LaunchDarkly.Server.Network.Polling (pollingThread, PollingResponse) where
 
 import           GHC.Generics                            (Generic)
 import           Data.HashMap.Strict                     (HashMap)

--- a/src/LaunchDarkly/Server/Store.hs
+++ b/src/LaunchDarkly/Server/Store.hs
@@ -6,6 +6,7 @@ module LaunchDarkly.Server.Store
     , FeatureNamespace
     , StoreInterface(..)
     , RawFeature(..)
+    , initializeStore
     ) where
 
 import LaunchDarkly.Server.Store.Internal

--- a/test/Spec/Evaluate.hs
+++ b/test/Spec/Evaluate.hs
@@ -4,7 +4,6 @@ module Spec.Evaluate (allTests) where
 import           Test.HUnit
 import           Data.Aeson                        (encodeFile)
 import           Data.Aeson.Types                  (Value(..))
-import           Data.Aeson.QQ                     (aesonQQ)
 import qualified Data.HashMap.Strict as            HM
 import           Data.Function                     ((&))
 import           Data.Generics.Product             (getField)
@@ -20,6 +19,7 @@ import           LaunchDarkly.Server.Features
 import           LaunchDarkly.Server.Operators
 import           LaunchDarkly.Server.Evaluate
 import           LaunchDarkly.Server.Config
+import           LaunchDarkly.Server.Network.Polling
 
 import           Util.Features
 
@@ -378,12 +378,7 @@ withTestClient :: (Client -> IO ()) -> IO ()
 withTestClient action = do
   System.IO.Temp.withSystemTempFile "flags" $ \filePath handle -> do
     System.IO.hClose handle
-    encodeFile filePath [aesonQQ|
-      {
-        "flags": {},
-        "segments": {}
-      }
-    |]
+    encodeFile filePath PollingResponse { flags = mempty, segments = mempty }
     (Client client) <- makeClient $ (makeConfig "") & configSetOffline (Just filePath)
     _ <- initializeStore (getField @"store" client) mempty mempty
     action (Client client)


### PR DESCRIPTION
**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

N/A

**Describe the solution you've provided**

We've exposed the store initialization function in order to allow us to seed the Flag and Segment caches after we create an offline client.

**Describe alternatives you've considered**

We considered adding in the hashmaps as an optional part of the offline configuration. We decided that we wanted to make the minimal changes to avoid supporting this fork for a long time.

**Additional context**

We at SimSpace are in the process of evaluating LaunchDarkly and this SDK, and in the process of doing this we found we needed to expose some stuff. In particular, we have a non-negotiable need to expose functionality to seed the offline mode with static data, and to update that data as required. We haven't flushed all of that out yet, so more changes may be required.