### PR TITLE
Drop bytestring-conversion dependency

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -23,7 +23,6 @@ dependencies:
 - base >=4.7 && <5
 - base16-bytestring >=0.1.1.6 && <1.1
 - bytestring >=0.10.8.2 && <0.11
-- bytestring-conversion >=0.3.1 && <0.4
 - clock ==0.8.*
 - containers >=0.6.0.1 && <0.7
 - cryptohash >=0.11.9 && <0.12


### PR DESCRIPTION
It looks like it's unused and it's blocking a dependency update in our codebase. 