### PR TITLE
Allow bytestring < 0.12

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -22,7 +22,7 @@ dependencies:
 - attoparsec >=0.13.2.2 && <0.14
 - base >=4.7 && <5
 - base16-bytestring >=0.1.1.6 && <1.1
-- bytestring >=0.10.8.2 && <0.11
+- bytestring >=0.10.8.2 && <0.12
 - clock ==0.8.*
 - containers >=0.6.0.1 && <0.7
 - cryptohash >=0.11.9 && <0.12


### PR DESCRIPTION
Prepare launchdarkly-server-sdk to support newest versions of bytestring library.