### PR TITLE
removed lens and import cleanup

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -35,7 +35,6 @@ dependencies:
 - http-client-tls >=0.3.5.3 && <0.4
 - http-types >=0.12.3 && <0.13
 - iso8601-time >=0.1.5 && <0.2
-- lens >=4.17.1 && <4.20
 - lrucache >=1.2.0.1 && <1.3
 - monad-logger >=0.3.30 && <0.4
 - mtl >=2.2.2 && <2.3

--- a/src/LaunchDarkly/Server/Config.hs
+++ b/src/LaunchDarkly/Server/Config.hs
@@ -29,7 +29,6 @@ import Control.Monad.Logger                (LoggingT, runStdoutLoggingT)
 import Data.Generics.Product               (setField)
 import Data.Set                            (Set)
 import Data.Text                           (Text)
-import Data.Monoid                         (mempty)
 import GHC.Natural                         (Natural)
 import Network.HTTP.Client                 (Manager)
 

--- a/src/LaunchDarkly/Server/Evaluate.hs
+++ b/src/LaunchDarkly/Server/Evaluate.hs
@@ -1,17 +1,17 @@
 module LaunchDarkly.Server.Evaluate where
 
-import           Control.Lens                        ((%~))
+import           Data.Generics.Internal.VL           (over)
 import           Control.Monad                       (mzero, msum)
 import           Control.Monad.Extra                 (ifM, anyM, allM, firstJustM)
 import           Crypto.Hash.SHA1                    (hash)
 import           Data.Scientific                     (Scientific, floatingOrInteger)
-import           Data.Either                         (either, fromLeft)
+import           Data.Either                         (fromLeft)
 import           Data.Function                       ((&))
 import           Data.Aeson.Types                    (Value(..))
-import           Data.Maybe                          (maybe, fromJust, isJust, fromMaybe)
+import           Data.Maybe                          (fromJust, isJust, fromMaybe)
 import           Data.Text                           (Text)
 import           Data.Generics.Product               (getField, field)
-import           Data.List                           (genericIndex, null, find)
+import           Data.List                           (genericIndex, find)
 import qualified Data.Vector as                      V
 import qualified Data.Text as                        T
 import qualified Data.ByteString as                  B
@@ -130,7 +130,7 @@ getValueForVariationOrRollout :: Flag -> VariationOrRollout -> UserI -> Evaluati
 getValueForVariationOrRollout flag vr user reason =
     case variationIndexForUser vr user (getField @"key" flag) (getField @"salt" flag) of
         (Nothing, _)           -> errorDetail EvalErrorKindMalformedFlag
-        (Just x, inExperiment) -> (getVariation flag x reason) & field @"reason" %~ setInExperiment inExperiment
+        (Just x, inExperiment) -> (getVariation flag x reason) & field @"reason" `over` setInExperiment inExperiment
 
 setInExperiment :: Bool -> EvaluationReason -> EvaluationReason
 setInExperiment inExperiment reason = case reason of

--- a/src/LaunchDarkly/Server/Operators.hs
+++ b/src/LaunchDarkly/Server/Operators.hs
@@ -3,22 +3,21 @@ module LaunchDarkly.Server.Operators
     , getOperation
     ) where
 
-import Data.Maybe            (fromMaybe, isJust)
-import Data.Either           (fromRight)
-import Data.Text as          T
-import Data.Text             (Text, isPrefixOf, isInfixOf, isSuffixOf, unpack)
-import Data.Char             (isDigit)
-import Data.Text.Encoding    (encodeUtf8)
-import Data.Scientific       (Scientific, toRealFloat)
-import Data.Aeson.Types      (Value(..), FromJSON, ToJSON(..), withText, parseJSON)
-import Data.Time.ISO8601     (parseISO8601)
-import Data.Time.Clock       (UTCTime)
-import Data.Time.Clock.POSIX (POSIXTime, posixSecondsToUTCTime)
-import Data.SemVer           (Version, fromText, toText, metadata)
-import Control.Monad         (liftM2)
-import Control.Lens          ((.~))
-import GHC.Generics          (Generic)
-import Text.Regex.PCRE.Light (compileM, match)
+import Data.Maybe                (fromMaybe, isJust)
+import Data.Either               (fromRight)
+import Data.Text as              T
+import Data.Char                 (isDigit)
+import Data.Text.Encoding        (encodeUtf8)
+import Data.Scientific           (Scientific, toRealFloat)
+import Data.Aeson.Types          (Value(..), FromJSON, ToJSON(..), withText, parseJSON)
+import Data.Time.ISO8601         (parseISO8601)
+import Data.Time.Clock           (UTCTime)
+import Data.Time.Clock.POSIX     (POSIXTime, posixSecondsToUTCTime)
+import Data.SemVer               (Version, fromText, toText, metadata)
+import Control.Monad             (liftM2)
+import Data.Generics.Internal.VL ((.~))
+import GHC.Generics              (Generic)
+import Text.Regex.PCRE.Light     (compileM, match)
 
 data Op =
       OpIn

--- a/src/LaunchDarkly/Server/User/Internal.hs
+++ b/src/LaunchDarkly/Server/User/Internal.hs
@@ -7,7 +7,7 @@ module LaunchDarkly.Server.User.Internal
     ) where
 
 import           Data.Aeson                          (FromJSON, ToJSON, Value(..), (.:), (.:?), withObject, object, parseJSON, toJSON)
-import           Data.Foldable                       (fold, or)
+import           Data.Foldable                       (fold)
 import           Data.Generics.Product               (getField)
 import qualified Data.HashMap.Strict as              HM
 import           Data.HashMap.Strict                 (HashMap)


### PR DESCRIPTION
- removed lens and only using generic-lens. This will reduce the
dependency footprint a little bit.

**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [X] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

Redundancy in dependencies causing unnecessary dependency footprint

**Describe the solution you've provided**

Removed `lens` library. Replaced functions from `lens` with functions from `generic-lens`

**Describe alternatives you've considered**

n/a

**Additional context**

n/a
