### PR TITLE
check in Cabal file; basic GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,69 @@
+# modified from https://github.com/jgm/pandoc/blob/master/.github/workflows/ci.yml
+name: CI
+
+on:
+  push:
+    branches:
+    - '**'
+    paths-ignore: []
+  pull_request:
+    paths-ignore: []
+
+jobs:
+  linux:
+
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        versions:
+          - ghc: '8.6.5'
+            cabal: '3.6'
+          - ghc: '8.8.4'
+            cabal: '3.6'
+          - ghc: '8.10.7'
+            cabal: '3.6'
+          - ghc: '9.0.2'
+            cabal: '3.6'
+
+    steps:
+    - uses: actions/checkout@v2
+
+    # need to install older cabal/ghc versions from ppa repository
+
+    - name: Install recent cabal/ghc
+      uses: haskell/actions/setup@v1
+      with:
+        ghc-version: ${{ matrix.versions.ghc }}
+        cabal-version: ${{ matrix.versions.cabal }}
+
+    # declare/restore cached things
+    # caching doesn't work for scheduled runs yet
+    # https://github.com/actions/cache/issues/63
+
+    - name: Cache cabal global package db
+      id:   cabal-global
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cabal
+        key: ${{ runner.os }}-${{ matrix.versions.ghc }}-${{ matrix.versions.cabal }}-cabal-global-${{ hashFiles('cabal.project') }}
+
+    - name: Cache cabal work
+      id:   cabal-local
+      uses: actions/cache@v2
+      with:
+        path: |
+          dist-newstyle
+        key: ${{ runner.os }}-${{ matrix.versions.ghc }}-${{ matrix.versions.cabal }}-cabal-local
+
+    - name: Install dependencies
+      run: |
+        cabal update
+        cabal build all --dependencies-only --enable-tests --disable-optimization
+    - name: Build
+      run: |
+        cabal build all --enable-tests --disable-optimization 2>&1 | tee build.log
+    - name: Test
+      run: |
+        cabal test all --disable-optimization

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
-launchdarkly-server-sdk.cabal
 .stack-work/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .stack-work/*
+dist-newstyle

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # LaunchDarkly Server-side SDK for Haskell
 
-[![CircleCI](https://circleci.com/gh/launchdarkly/haskell-server-sdk.svg?style=svg)](https://circleci.com/gh/launchdarkly/haskell-server-sdk)
+[![CircleCI](https://circleci.com/gh/launchdarkly/haskell-server-sdk.svg?style=svg)](https://circleci.com/gh/launchdarkly/haskell-server-sdk)[![Build status](https://github.com/launchdarkly/haskell-server-sdk/actions/workflows/ci.yml/badge.svg)](https://github.com/launchdarkly/haskell-server-sdk/actions/workflows/ci.yml)
+
 
 The LaunchDarkly Server-side SDK for Haskell is designed primarily for use in multi-user systems such as web servers and applications. It follows the server-side LaunchDarkly model for multi-user contexts. It is not intended for use in desktop and embedded systems applications.
 

--- a/launchdarkly-server-sdk.cabal
+++ b/launchdarkly-server-sdk.cabal
@@ -1,0 +1,207 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.34.4.
+--
+-- see: https://github.com/sol/hpack
+
+name:           launchdarkly-server-sdk
+version:        2.2.0
+synopsis:       Server-side SDK for integrating with LaunchDarkly
+description:    Please see the README on GitHub at <https://github.com/launchdarkly/haskell-server-sdk#readme>
+category:       Web
+homepage:       https://github.com/launchdarkly/haskell-server-sdk#readme
+bug-reports:    https://github.com/launchdarkly/haskell-server-sdk/issues
+author:         LaunchDarkly
+maintainer:     dev@launchdarkly.com
+copyright:      2019 Catamorphic, Co
+license:        Apache-2.0
+license-file:   LICENSE
+build-type:     Simple
+extra-source-files:
+    README.md
+    CHANGELOG.md
+    LICENSE
+
+source-repository head
+  type: git
+  location: https://github.com/launchdarkly/haskell-server-sdk
+
+library
+  exposed-modules:
+      LaunchDarkly.Server
+      LaunchDarkly.Server.Client
+      LaunchDarkly.Server.Config
+      LaunchDarkly.Server.User
+      LaunchDarkly.Server.Store
+  other-modules:
+      LaunchDarkly.Server.Client.Internal
+      LaunchDarkly.Server.Config.Internal
+      LaunchDarkly.Server.Details
+      LaunchDarkly.Server.Evaluate
+      LaunchDarkly.Server.Events
+      LaunchDarkly.Server.Features
+      LaunchDarkly.Server.Network.Common
+      LaunchDarkly.Server.Network.Eventing
+      LaunchDarkly.Server.Network.Polling
+      LaunchDarkly.Server.Network.Streaming
+      LaunchDarkly.Server.Operators
+      LaunchDarkly.Server.Store.Internal
+      LaunchDarkly.Server.User.Internal
+      Paths_launchdarkly_server_sdk
+  hs-source-dirs:
+      src
+  default-extensions:
+      AllowAmbiguousTypes
+      DataKinds
+      DeriveAnyClass
+      DeriveGeneric
+      DerivingStrategies
+      DuplicateRecordFields
+      FlexibleContexts
+      FlexibleInstances
+      GeneralizedNewtypeDeriving
+      LambdaCase
+      MonoLocalBinds
+      MultiParamTypeClasses
+      MultiWayIf
+      NoMonomorphismRestriction
+      OverloadedStrings
+      RankNTypes
+      RecordWildCards
+      ScopedTypeVariables
+      TemplateHaskell
+      TupleSections
+      TypeApplications
+      TypeOperators
+  ghc-options: -fwarn-unused-imports -Wall -Wno-name-shadowing
+  build-depends:
+      aeson >=1.4.4.0 && <1.6
+    , attoparsec >=0.13.2.2 && <0.14
+    , base >=4.7 && <5
+    , base16-bytestring >=0.1.1.6 && <1.1
+    , bytestring >=0.10.8.2 && <0.12
+    , clock ==0.8.*
+    , containers >=0.6.0.1 && <0.7
+    , cryptohash >=0.11.9 && <0.12
+    , exceptions >=0.10.2 && <0.11
+    , extra >=1.6.17 && <1.8
+    , generic-lens >=1.1.0.0 && <2.2
+    , hashtables >=1.2.3.4 && <1.3
+    , hedis >=0.12.7 && <0.15
+    , http-client >=0.6.4 && <0.8
+    , http-client-tls >=0.3.5.3 && <0.4
+    , http-types >=0.12.3 && <0.13
+    , iso8601-time >=0.1.5 && <0.2
+    , lens >=4.17.1 && <4.20
+    , lrucache >=1.2.0.1 && <1.3
+    , monad-logger >=0.3.30 && <0.4
+    , mtl >=2.2.2 && <2.3
+    , pcre-light >=0.4.0.4 && <0.5
+    , random >=1.1 && <1.3
+    , retry >=0.8.0.1 && <0.9
+    , scientific >=0.3.6.2 && <0.4
+    , semver >=0.3.4 && <0.5
+    , text >=1.2.3.1 && <1.3
+    , time >=1.8.0.2 && <1.11
+    , unordered-containers >=0.2.10.0 && <0.3
+    , uuid >=1.3.13 && <1.4
+    , vector >=0.12.0.3 && <0.13
+  default-language: Haskell2010
+
+test-suite haskell-server-sdk-test
+  type: exitcode-stdio-1.0
+  main-is: Spec.hs
+  other-modules:
+      Spec.Bucket
+      Spec.Evaluate
+      Spec.Operators
+      Spec.Redis
+      Spec.Segment
+      Spec.Store
+      Spec.StoreInterface
+      Spec.Streaming
+      Spec.User
+      Util.Features
+      LaunchDarkly.Server
+      LaunchDarkly.Server.Client
+      LaunchDarkly.Server.Client.Internal
+      LaunchDarkly.Server.Config
+      LaunchDarkly.Server.Config.Internal
+      LaunchDarkly.Server.Details
+      LaunchDarkly.Server.Evaluate
+      LaunchDarkly.Server.Events
+      LaunchDarkly.Server.Features
+      LaunchDarkly.Server.Network.Common
+      LaunchDarkly.Server.Network.Eventing
+      LaunchDarkly.Server.Network.Polling
+      LaunchDarkly.Server.Network.Streaming
+      LaunchDarkly.Server.Operators
+      LaunchDarkly.Server.Store
+      LaunchDarkly.Server.Store.Internal
+      LaunchDarkly.Server.User
+      LaunchDarkly.Server.User.Internal
+      LaunchDarkly.Server.Store.Redis
+      LaunchDarkly.Server.Store.Redis.Internal
+      Paths_launchdarkly_server_sdk
+  hs-source-dirs:
+      test
+      src
+      stores/launchdarkly-server-sdk-redis/src
+  default-extensions:
+      AllowAmbiguousTypes
+      DataKinds
+      DeriveAnyClass
+      DeriveGeneric
+      DerivingStrategies
+      DuplicateRecordFields
+      FlexibleContexts
+      FlexibleInstances
+      GeneralizedNewtypeDeriving
+      LambdaCase
+      MonoLocalBinds
+      MultiParamTypeClasses
+      MultiWayIf
+      NoMonomorphismRestriction
+      OverloadedStrings
+      RankNTypes
+      RecordWildCards
+      ScopedTypeVariables
+      TemplateHaskell
+      TupleSections
+      TypeApplications
+      TypeOperators
+  ghc-options: -rtsopts -threaded -with-rtsopts=-N -Wno-name-shadowing
+  build-depends:
+      HUnit
+    , aeson >=1.4.4.0 && <1.6
+    , attoparsec >=0.13.2.2 && <0.14
+    , base >=4.7 && <5
+    , base16-bytestring >=0.1.1.6 && <1.1
+    , bytestring >=0.10.8.2 && <0.12
+    , clock ==0.8.*
+    , containers >=0.6.0.1 && <0.7
+    , cryptohash >=0.11.9 && <0.12
+    , exceptions >=0.10.2 && <0.11
+    , extra >=1.6.17 && <1.8
+    , generic-lens >=1.1.0.0 && <2.2
+    , hashtables >=1.2.3.4 && <1.3
+    , hedis >=0.12.7 && <0.15
+    , http-client >=0.6.4 && <0.8
+    , http-client-tls >=0.3.5.3 && <0.4
+    , http-types >=0.12.3 && <0.13
+    , iso8601-time >=0.1.5 && <0.2
+    , lens >=4.17.1 && <4.20
+    , lrucache >=1.2.0.1 && <1.3
+    , monad-logger >=0.3.30 && <0.4
+    , mtl >=2.2.2 && <2.3
+    , pcre-light >=0.4.0.4 && <0.5
+    , random >=1.1 && <1.3
+    , retry >=0.8.0.1 && <0.9
+    , scientific >=0.3.6.2 && <0.4
+    , semver >=0.3.4 && <0.5
+    , text >=1.2.3.1 && <1.3
+    , time >=1.8.0.2 && <1.11
+    , unordered-containers >=0.2.10.0 && <0.3
+    , uuid >=1.3.13 && <1.4
+    , vector >=0.12.0.3 && <0.13
+  default-language: Haskell2010


### PR DESCRIPTION
This allows the project to be built with Cabal. In its current state I think `haskell-server-sdk` cannot be used as a pinned dependency in a `cabal.project`; this error is given: `NoCabalFileFound`
 
Basic GitHub Actions for the Cabal file are provided. Everything works for GHC 8.6, 8.8, and 8.10, but GHC 9.0 fails: https://github.com/peterbecich/haskell-server-sdk/runs/5255432273?check_suite_focus=true

**Requirements**

- [x] I have added test coverage for new or changed functionality
- [ ] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**


**Describe the solution you've provided**

Check in `haskell-server-sdk.cabal` generated by Stack from `package.yaml`.

**Describe alternatives you've considered**



**Additional context**


