### PR TITLE
Regenerate .hlint.yaml from hlint --default with counts.

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -1,1 +1,26 @@
-arguments: [-XTypeApplications]
+# Warnings currently triggered by your code
+- ignore: {name: "Avoid lambda"} # 1 hint
+- ignore: {name: "Eta reduce"} # 3 hints
+- ignore: {name: "Functor law"} # 2 hints
+- ignore: {name: "Monad law, right identity"} # 1 hint
+- ignore: {name: "Move brackets to avoid $"} # 12 hints
+- ignore: {name: "Parse error: on input `pattern'"} # 1 hint
+- ignore: {name: "Redundant $"} # 7 hints
+- ignore: {name: "Redundant <&>"} # 11 hints
+- ignore: {name: "Redundant =="} # 1 hint
+- ignore: {name: "Redundant bracket"} # 68 hints
+- ignore: {name: "Redundant fromInteger"} # 25 hints
+- ignore: {name: "Use <$>"} # 2 hints
+- ignore: {name: "Use <&>"} # 6 hints
+- ignore: {name: "Use >=>"} # 1 hint
+- ignore: {name: "Use fewer imports"} # 3 hints
+- ignore: {name: "Use first"} # 1 hint
+- ignore: {name: "Use if"} # 3 hints
+- ignore: {name: "Use infix"} # 6 hints
+- ignore: {name: "Use let"} # 3 hints
+- ignore: {name: "Use maybe"} # 4 hints
+- ignore: {name: "Use newtype instead of data"} # 4 hints
+- ignore: {name: "Use section"} # 4 hints
+- ignore: {name: "Use unless"} # 1 hint
+
+- arguments: [-XTypeApplications]


### PR DESCRIPTION
There's 170 hlint hints here. This change shows these warnings and suggestions by category with counts. This enables a later workflow where individual ignore lines can be removed from `.hlint.yaml` and that category of hlint suggestion tackled in isolation such as "Use fewer imports".
