### PR TITLE
Avoid hlint parse error on "pattern", rerun hlint --default.

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -4,12 +4,13 @@
 - ignore: {name: "Functor law"} # 2 hints
 - ignore: {name: "Monad law, right identity"} # 1 hint
 - ignore: {name: "Move brackets to avoid $"} # 12 hints
-- ignore: {name: "Parse error: on input `pattern'"} # 1 hint
 - ignore: {name: "Redundant $"} # 7 hints
 - ignore: {name: "Redundant <&>"} # 11 hints
 - ignore: {name: "Redundant =="} # 1 hint
-- ignore: {name: "Redundant bracket"} # 68 hints
+- ignore: {name: "Redundant bracket"} # 69 hints
+- ignore: {name: "Redundant fmap"} # 1 hint
 - ignore: {name: "Redundant fromInteger"} # 25 hints
+- ignore: {name: "Redundant where"} # 1 hint
 - ignore: {name: "Use <$>"} # 2 hints
 - ignore: {name: "Use <&>"} # 6 hints
 - ignore: {name: "Use >=>"} # 1 hint
@@ -17,6 +18,7 @@
 - ignore: {name: "Use first"} # 1 hint
 - ignore: {name: "Use if"} # 3 hints
 - ignore: {name: "Use infix"} # 6 hints
+- ignore: {name: "Use lambda-case"} # 1 hint
 - ignore: {name: "Use let"} # 3 hints
 - ignore: {name: "Use maybe"} # 4 hints
 - ignore: {name: "Use newtype instead of data"} # 4 hints

--- a/src/LaunchDarkly/Server/Operators.hs
+++ b/src/LaunchDarkly/Server/Operators.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE NoPatternSynonyms #-}
+
 module LaunchDarkly.Server.Operators
     ( Op(..)
     , getOperation


### PR DESCRIPTION
HLint enables extensions but for the Operators module this is a problem for "pattern". I chose to disable pattern synonyms for this module but we could have renamed the pattern binding instead. With the parse error avoided, hlint finds more suggestions for us.
