### PR TITLE
Add configSetLoggerFilteringDebug function for Config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ contract-tests/contract-tests.cabal
 **/.stack-work/*
 dist-newstyle/
 stack.yaml.lock
+.ghc.environment.*

--- a/src/LaunchDarkly/Server/Config.hs
+++ b/src/LaunchDarkly/Server/Config.hs
@@ -18,6 +18,7 @@ module LaunchDarkly.Server.Config
     , configSetUserKeyLRUCapacity
     , configSetEventsCapacity
     , configSetLogger
+    , configSetLoggerFilteringDebug
     , configSetManager
     , configSetSendEvents
     , configSetOffline
@@ -32,7 +33,7 @@ module LaunchDarkly.Server.Config
     , withApplicationValue
     ) where
 
-import Control.Monad.Logger (LoggingT, runStdoutLoggingT)
+import Control.Monad.Logger (LogLevel (LevelDebug), LoggingT, filterLogger, runStdoutLoggingT)
 import Data.Generics.Product (setField)
 import Data.Set (Set)
 import Data.Text (Text, dropWhileEnd)
@@ -170,6 +171,13 @@ configSetEventsCapacity = setField @"eventsCapacity"
 -- | Set the logger to be used by the client.
 configSetLogger :: (LoggingT IO () -> IO ()) -> Config -> Config
 configSetLogger = setField @"logger"
+
+-- | Set the logger to be used by the client with the 'LevelDebug' messages
+-- filtered out.
+configSetLoggerFilteringDebug :: Config -> Config
+configSetLoggerFilteringDebug =
+    configSetLogger
+        (runStdoutLoggingT . filterLogger (\_ lvl -> lvl /= LevelDebug))
 
 -- |
 -- Sets whether to send analytics events back to LaunchDarkly. By default,

--- a/test/Spec/Integrations/FileData.hs
+++ b/test/Spec/Integrations/FileData.hs
@@ -4,7 +4,6 @@ where
 import Test.HUnit
 
 import Control.Exception
-import Control.Monad.Logger
 import Data.Generics.Product (getField)
 import qualified Data.HashSet as HS
 import LaunchDarkly.AesonCompat (emptyObject)
@@ -35,7 +34,7 @@ testConfig :: DataSourceFactory -> Config
 testConfig factory =
     configSetSendEvents False $
         configSetDataSourceFactory (Just factory) $
-            configSetLogger (runStdoutLoggingT . filterLogger (\_ lvl -> lvl /= LevelDebug)) $
+            configSetLoggerFilteringDebug $
                 makeConfig "sdk-key"
 
 testAllProperties :: Test

--- a/test/Spec/Integrations/TestData.hs
+++ b/test/Spec/Integrations/TestData.hs
@@ -9,7 +9,6 @@ import Data.Functor ((<&>))
 import Data.Text (Text)
 import GHC.Generics (Generic)
 
-import Control.Monad.Logger
 import LaunchDarkly.Server
 import LaunchDarkly.Server.DataSource.Internal
 import qualified LaunchDarkly.Server.Integrations.TestData as TestData
@@ -30,7 +29,7 @@ testConfig :: DataSourceFactory -> Config
 testConfig factory =
     configSetSendEvents False $
         configSetDataSourceFactory (Just factory) $
-            configSetLogger (runStdoutLoggingT . filterLogger (\_ lvl -> lvl /= LevelDebug)) $
+            configSetLoggerFilteringDebug $
                 makeConfig "sdk-key"
 
 testVariationForAll :: Test


### PR DESCRIPTION
**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

Often, you need a function that would filter out the `Debug` messages before logging.
Currently, you can do that with the manual dependency on the monad-logger and setting the alternative logger.
With `configSetLoggerFilteringDebug` function you can do that easier.

**Additional context**

I also noticed, that it is already was used in the tests, so I reuse the function in there already, so it tests it as well.
