### PR TITLE
fix: Bump aeson bounds to accept aeson-2.2.1.0

### DIFF
--- a/launchdarkly-server-sdk.cabal
+++ b/launchdarkly-server-sdk.cabal
@@ -94,7 +94,7 @@ library
       TypeOperators
   ghc-options: -fwarn-unused-imports -Wall -Wno-name-shadowing
   build-depends:
-      aeson >=1.4.7.1 && <1.6 || >=2.0.1.0 && <2.2
+      aeson >=1.4.7.1 && <1.6 || >=2.0.1.0 && <2.3
     , attoparsec >=0.13.2.4 && <0.15
     , base >=4.13 && <5
     , base16-bytestring >=0.1.1.7 && <1.1

--- a/launchdarkly-server-sdk.cabal
+++ b/launchdarkly-server-sdk.cabal
@@ -204,7 +204,7 @@ test-suite haskell-server-sdk-test
   ghc-options: -rtsopts -threaded -with-rtsopts=-N -Wno-name-shadowing -fwarn-unused-imports
   build-depends:
       HUnit
-    , aeson >=1.4.7.1 && <1.6 || >=2.0.1.0 && <2.2
+    , aeson >=1.4.7.1 && <1.6 || >=2.0.1.0 && <2.3
     , attoparsec >=0.13.2.4 && <0.15
     , base >=4.13 && <5
     , base16-bytestring >=0.1.1.7 && <1.1

--- a/package.yaml
+++ b/package.yaml
@@ -19,7 +19,7 @@ category:            Web
 description:         Please see the README on GitHub at <https://github.com/launchdarkly/haskell-server-sdk#readme>
 
 dependencies:
-- aeson >=1.4.7.1 && <1.6 || >= 2.0.1.0 && <2.2
+- aeson >=1.4.7.1 && <1.6 || >= 2.0.1.0 && <2.3
 - attoparsec >=0.13.2.4 && <0.15
 - base >=4.13 && <5
 - base16-bytestring >=0.1.1.7 && <1.1


### PR DESCRIPTION
**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions


**Describe the solution you've provided**

This PR bumps the aeson dependency bounds to accept aeson-2.2.1.0.
