### PR TITLE
feat: Support ldcli's dev-server

### DIFF
--- a/src/LaunchDarkly/Server/Network/Streaming.hs
+++ b/src/LaunchDarkly/Server/Network/Streaming.hs
@@ -27,7 +27,7 @@ import System.Clock (Clock (Monotonic), TimeSpec (TimeSpec), getTime)
 import System.Random (Random (randomR), newStdGen)
 import System.Timeout (timeout)
 
-import LaunchDarkly.AesonCompat (KeyMap)
+import LaunchDarkly.AesonCompat (KeyMap, emptyObject)
 import LaunchDarkly.Server.Config.ClientContext (ClientContext (..))
 import LaunchDarkly.Server.Config.HttpConfiguration (HttpConfiguration (..), prepareRequest)
 import LaunchDarkly.Server.DataSource.Internal (DataSourceUpdates (..))
@@ -39,7 +39,7 @@ data PutBody = PutBody
     { flags :: !(KeyMap Flag)
     , segments :: !(KeyMap Segment)
     }
-    deriving (Generic, Show, FromJSON)
+    deriving (Generic, Show)
 
 data PathData d = PathData
     { path :: !Text
@@ -52,6 +52,12 @@ data PathVersion = PathVersion
     , version :: !Natural
     }
     deriving (Generic, Show, FromJSON)
+
+instance FromJSON PutBody where
+    parseJSON = withObject "PutBody" $ \o -> do
+        flags <- o .: "flags"
+        segments <- o .:? "segments" .!= emptyObject
+        pure $ PutBody {flags = flags, segments = segments}
 
 instance FromJSON a => FromJSON (PathData a) where
     parseJSON = withObject "Put" $ \o -> do


### PR DESCRIPTION
**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

**Describe the solution you've provided**

The LaunchDarkly CLI provides a development server for local testing (https://docs.launchdarkly.com/guides/flags/ldcli-dev-server). Its streaming format is slightly different than stream.launchdarkly.com in that:

- it lacks `segments` field;
- it emits an additional newline after comment (`:\n\n` as opposed to `:\n`).

To overcome these differences, I modified how it parses JSON and server-sent events. I've confirmed that `stack test` passed for lts-20.26.

**Describe alternatives you've considered**

**Additional context**


BEGIN_COMMIT_OVERRIDE
fix: Fix SSE newline handling
fix: Handle optional properties in data payload
END_COMMIT_OVERRIDE