### PR TITLE
ci: split release-please into independent release and PR creation steps

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,7 +14,7 @@ jobs:
       pull-requests: write
 
     outputs:
-      releases_created: ${{ steps.release.outputs.releases_created }}
+      release_created: ${{ steps.release.outputs.release_created }}
 
     steps:
       # Create any releases first, then create tags, and then optionally create any new PRs.
@@ -63,7 +63,7 @@ jobs:
 
   release-package:
     needs: release-please
-    if: ${{ needs.release-please.outputs.releases_created == 'true' }}
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
     runs-on: ubuntu-latest
 
     permissions:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -6,69 +6,106 @@ on:
       - main
 
 jobs:
-  release-package:
+  release-please:
     runs-on: ubuntu-latest
 
     permissions:
-      id-token: write # Needed if using OIDC to get release secrets.
       contents: write # Contents and pull-requests are for release-please to make releases.
       pull-requests: write
-      attestations: write
+
+    outputs:
+      releases_created: ${{ steps.release.outputs.releases_created }}
 
     steps:
-      - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4
+      # Create any releases first, then create tags, and then optionally create any new PRs.
+      - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0
         id: release
-
-      - uses: actions/checkout@v4
         with:
-          fetch-depth: 0 # Full history is required for proper changelog generation
+          skip-github-pull-request: true
+
+      # Need the repository content to be able to create and push a tag.
+      - uses: actions/checkout@v4
+        if: ${{ steps.release.outputs.release_created == 'true' }}
+
+      - name: Create release tag
+        if: ${{ steps.release.outputs.release_created == 'true' }}
+        env:
+          TAG_NAME: ${{ steps.release.outputs.tag_name }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh api "repos/${{ github.repository }}/git/ref/tags/${TAG_NAME}" >/dev/null 2>&1; then
+            echo "Tag ${TAG_NAME} already exists, skipping creation."
+          else
+            echo "Creating tag ${TAG_NAME}."
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git tag "${TAG_NAME}"
+            git push origin "${TAG_NAME}"
+          fi
+
+      - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0
+        if: ${{ steps.release.outputs.release_created != 'true' }}
+        id: release-prs
+        with:
+          skip-github-release: true
+
+      # Checkout is needed for the update-cabal step below.
+      - uses: actions/checkout@v4
+        if: ${{ steps.release-prs.outputs.pr != '' }}
 
       #
       # This step runs and updates an existing PR
       #
       - uses: ./.github/actions/update-cabal
-        if: ${{ steps.release.outputs.pr != '' }}
+        if: ${{ steps.release-prs.outputs.pr != '' }}
         with:
-          branch: ${{ fromJSON(steps.release.outputs.pr).headBranchName }}
+          branch: ${{ fromJSON(steps.release-prs.outputs.pr).headBranchName }}
+
+  release-package:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.releases_created == 'true' }}
+    runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write # Needed if using OIDC to get release secrets.
+      contents: write # Contents and pull-requests are for release-please to make releases.
+      attestations: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Full history is required for proper changelog generation
 
       - uses: launchdarkly/gh-actions/actions/release-secrets@release-secrets-v1.2.0
         name: "Get Hackage token"
-        if: ${{ steps.release.outputs.releases_created == 'true' }}
         with:
           aws_assume_role: ${{ vars.AWS_ROLE_ARN }}
           ssm_parameter_pairs: "/production/common/releasing/hackage/password = HACKAGE_TOKEN"
 
       - name: Install PCRE development libraries
-        if: ${{ steps.release.outputs.releases_created == 'true' }}
         run: sudo apt-get update && sudo apt-get install -y libpcre3-dev
 
       - uses: ./.github/actions/setup-cache
-        if: ${{ steps.release.outputs.releases_created == 'true' }}
 
       - uses: ./.github/actions/ci
         id: ci
-        if: ${{ steps.release.outputs.releases_created == 'true' }}
         with:
           token: ${{secrets.GITHUB_TOKEN}}
 
       - uses: ./.github/actions/build-docs
-        if: ${{ steps.release.outputs.releases_created == 'true' }}
 
       - uses: ./.github/actions/publish
-        if: ${{ steps.release.outputs.releases_created == 'true' }}
         with:
           token: ${{ env.HACKAGE_TOKEN }}
           dry_run: "false"
 
       - uses: ./.github/actions/publish-docs
-        if: ${{ steps.release.outputs.releases_created == 'true' }}
         with:
           # If publishing somewhere else, then get the token from SSM. If you need both github,
           # and another token, then add more tokens to the composite action.
           token: ${{secrets.GITHUB_TOKEN}}
 
       - name: Attest build provenance
-        if: ${{ steps.release.outputs.releases_created == 'true' }}
         uses: actions/attest@v4
         with:
           subject-path: '${{ steps.ci.outputs.dist-dir }}/*tar.gz'


### PR DESCRIPTION
**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [ ] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

Follows the pattern established in [ld-relay PR #622](https://github.com/launchdarkly/ld-relay/pull/622) to support GitHub's immutable releases.

**Describe the solution you've provided**

Splits the single `release-package` job into two jobs (`release-please` + `release-package`) and uses a two-pass release-please invocation:

1. **Pass 1** (`skip-github-pull-request: true`): Attempts to create a release. If successful, checks out the repo and pushes the tag explicitly (with an idempotency guard).
2. **Pass 2** (`skip-github-release: true`): Only runs if no release was created. Handles PR creation/maintenance.
3. **`release-package` job**: Runs only when `releases_created == 'true'`, containing all build/publish/attest steps without per-step `if` guards.

This separation is required because release-please checks for an existing tag to decide whether a release PR is still needed. Without the split, it could open a duplicate PR before the tag is available.

**Items requiring careful review:**

- The `update-cabal` step now references `steps.release-prs.outputs.pr` (from pass 2) instead of the old `steps.release.outputs.pr` (from pass 1). Since pass 1 uses `skip-github-pull-request: true`, it won't emit PR outputs — so `update-cabal` must use the pass 2 step ID. Verify this is correct.
- The checkout preceding `update-cabal` does **not** use `fetch-depth: 0` (unlike the `release-package` job checkout). Confirm `update-cabal` doesn't require full history.
- `update-cabal` now only runs when no release was created (since pass 2 is skipped on release runs). Previously it ran whenever a PR existed, even during a release run. This should be fine (no PR to update during a release), but worth confirming.

**Describe alternatives you've considered**

Could keep a single job with per-step `if` conditions, but splitting into two jobs follows the established pattern across the org and makes the release-please logic self-contained.

**Additional context**

- The pinned SHA `16a9c90856f42705d54a6fda1823352bdc62cf38` is unchanged; only the version comment was updated from `# v4` to `# v4.4.0`.
- The `release-package` job drops `pull-requests: write` since it no longer runs release-please.

Link to Devin session: https://app.devin.ai/sessions/7d5bda4d9dbe4ae0b950b30a50485e60
Requested by: @keelerm84

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the release workflow control flow (two-pass `release-please`, manual tag creation, and a new gated packaging job), which could impact how/when releases and release PRs are created. No product code changes, but misconfiguration could break releases or create missing/duplicate tags/PRs.
> 
> **Overview**
> **Splits the GitHub Actions release workflow into two jobs**: a `release-please` job that decides whether to cut a GitHub Release or open/update a release PR, and a `release-package` job that runs build/publish/attestation only when a release was actually created.
> 
> `release-please` is now invoked twice: first to create the GitHub Release (with PR creation disabled) and, on success, explicitly creates/pushes the git tag with an idempotency check; second (only when no release was created) to manage release PRs and run `update-cabal` against the PR branch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 407a6be6d034902fdb7eb19655425f84dca46c8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->